### PR TITLE
Undefined 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Server-side response caching plugin for [hapi](http://hapijs.com/)
 [![Current Version](https://img.shields.io/npm/v/tacky.svg)](https://www.npmjs.org/package/tacky)
 [![Build Status](https://travis-ci.org/continuationlabs/tacky.svg)](https://travis-ci.org/continuationlabs/tacky)
 
-tacky adds a new handler named `cache` that can be used on any route that is a "get" method. tacky will try to serve a value from the server cache if present. If the value is not in the server cache, it will call a `hydrate` function, reply with the result and the cache the value in the server cache for subsequent requests. tacky stores values in a hapi server cache provision. It does *not* just set the response cache headers.
+tacky adds a new handler named `cache` that can be used on any route that is a `GET` method. tacky will try to serve a value from the server cache first if present. If the value is not in the server cache, it will call `hydrate()`, reply with the result and then cache the value in the server cache for subsequent requests. tacky stores values in a hapi server cache provision. It does *not* just set the response cache headers.
 
 ## Example
 _copied from examples/defualt.js_
@@ -72,7 +72,7 @@ These are the available options passed into Tack during plugin registration (`se
 
 - `hydrate` - a function used to get data when absent from the cache. Must have the following signature: `function (request, callback)` where:
   - `request` - the incoming hapi request
-  - `callback(err, result, state)` - function to execute when hydrate is finished.
+  - `callback(err, result[, state])` - function to execute when hydrate is finished.
     - `err` - any error during processing. If this value is truthy, the request will result in a 500 and the request will _not_ be cached.
     - `result` - the value to save in the cache.
     - `[state]` - this value will be attached to `request.response.plugins.tacky` so it will be available during the various request lifecycle methods. Defaults to `undefined`.
@@ -81,28 +81,30 @@ These are the available options passed into Tack during plugin registration (`se
   - `request` - incoming hapi request object.
 
 __context__
-The `this` pointed for `hydrate` and `generateKey` can be controlled via the `bind` option for the [route handler](https://github.com/hapijs/hapi/blob/master/API.md#route-options).
+The `this` pointer for `hydrate` and `generateKey` can be controlled via the `bind` option for the [route handler](https://github.com/hapijs/hapi/blob/master/API.md#route-options).
 
 Example:
 
 ```js
-handler: {
-  cache: {
-    hydrate: function (request, callback) {
-
-      // this is {foo: 'bar', baz: true}
-      callback(null, this.baz);
-    },
-    generateKey: function (request) {
-
-      // this is {foo: 'bar', baz: true}
-      // don't do this because nothing will cache
-      return Date.now() + this.foo;
+config: {
+  handler: {
+    cache: {
+      hydrate: function (request, callback) {
+  
+        // this is {foo: 'bar', baz: true}
+        callback(null, this.baz);
+      },
+      generateKey: function (request) {
+  
+        // this is {foo: 'bar', baz: true}
+        // don't do this because nothing will cache
+        return Date.now() + this.foo;
+      }
     }
+  },
+  bind: {
+    foo: 'bar',
+    baz: true
   }
-},
-bind: {
-  foo: 'bar',
-  baz: true
 }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var Hoek = require('hoek');
+var Insync = require('insync');
 
 var defaults = {
     expiresIn: 3600000,
@@ -16,23 +17,13 @@ exports.register = function (server, options, next) {
         cache: internals.settings.cache
     });
 
+    server.ext('onPreResponse', internals.extensionPoint);
     server.handler('cache', internals.handler);
     next();
 };
 
 exports.register.attributes = {
     pkg: require('../package.json')
-};
-
-internals.getCacheString = function (ttl, privacy) {
-
-    var age = Math.floor(ttl / 1000);
-    var header = 'max-age=' + age + ', must-revalidate';
-
-    if (privacy !== 'default') {
-        header += ', ' + privacy;
-    }
-    return header;
 };
 
 internals.handler = function (route, options) {
@@ -57,34 +48,83 @@ internals.handler = function (route, options) {
         var cacheKey = settings.generateKey.call(context, request);
         var privacy = options.privacy || internals.settings.privacy;
 
-        Hoek.assert(typeof cacheKey === 'string', 'generateKey must return a string.');
-
-        internals.cache.get(cacheKey, function (err, value, cached) {
+        // Waterfall functions
+        var hydrate = settings.hydrate.bind(context, request);
+        var done = function (err, data) {
 
             if (err) {
-                request.log(['cache', 'error'], {
-                    message: 'Error looking up ' + cacheKey + ' in the cache',
-                    error: err
-                });
+                return reply(err);
             }
 
-            if (cached) {
-                return reply(value).header('cache-control', internals.getCacheString(cached.ttl, privacy));
-            }
+            var response = reply(data.result);
+            response.plugins.tacky = {
+                cache: data.cache,
+                state: data.state
+            };
+        };
+        var afterHydrate = function (cacheSettings) {
 
-            settings.hydrate.call(context, request, function (err, result, state) {
+            return function (result /*, [state], [next]*/) {
 
-                if (err) {
-                    return reply(err);
+                var next;
+                var state;
+                if (arguments.length === 3) {
+                    state = arguments[1];
+                    next = arguments[2];
+                }
+                else {
+                    state = null;
+                    next = arguments[1];
                 }
 
-                var cacheTail = request.tail('cache tail');
-                var response = reply(result);
-                response.plugins.tacky = state;
+                next(null, {
+                    result: result,
+                    state: state,
+                    cache: cacheSettings
+                });
+            };
+        };
+        var checkCache = function (next) {
 
-                response.header('cache-control', internals.getCacheString(internals.settings.expiresIn, privacy));
+            internals.cache.get(cacheKey, function (err, value, cached) {
 
-                internals.cache.set(cacheKey, result, null, function (cacheErr) {
+                if (err) {
+                    request.log(['cache', 'error'], {
+                        message: 'Error looking up ' + cacheKey + ' in the cache',
+                        error: err
+                    });
+                }
+
+                // If the value is in the cache, short-circuit the waterfall and
+                // call out to the end. This is the documented way to short-circuit
+                // a Insync waterfall.
+                if (cached) {
+                    return done(null, {
+                        result: value,
+                        cache: {
+                            ttl: cached.ttl,
+                            privacy: privacy
+                        },
+                        state: null
+                    });
+                }
+                next(null);
+            });
+        };
+
+        var tasks = [];
+        /* eslint-disable*/
+        if (cacheKey == null) {
+        /* eslint-enable*/
+            tasks.push(hydrate, afterHydrate(null));
+        }
+        else {
+            tasks.push(checkCache, hydrate);
+            tasks.push(afterHydrate({ ttl: internals.settings.expiresIn, privacy: privacy }));
+            tasks.push(function (data, next) {
+
+                var tail = request.tail('cache tail');
+                internals.cache.set(cacheKey, data.result, null, function (cacheErr) {
 
                     if (cacheErr) {
                         request.log(['cache', 'error'], {
@@ -92,9 +132,35 @@ internals.handler = function (route, options) {
                             error: cacheErr
                         });
                     }
-                    cacheTail();
+                    tail();
                 });
+                next(null, data);
             });
-        });
+        }
+
+        Insync.waterfall(tasks, done);
     };
+};
+
+internals.getCacheString = function (ttl, privacy) {
+
+    var age = Math.floor(ttl / 1000);
+    var header = 'max-age=' + age + ', must-revalidate';
+
+    if (privacy !== 'default') {
+        header += ', ' + privacy;
+    }
+    return header;
+};
+
+internals.extensionPoint = function (request, reply) {
+
+    var response = request.response;
+    var tacky = response.plugins.tacky;
+
+    if (tacky.cache) {
+        var cache = tacky.cache;
+        response.header('cache-control', internals.getCacheString(cache.ttl, cache.privacy));
+    }
+    reply.continue();
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "hoek": "2.12.x",
-    "insync": "^1.0.0"
+    "insync": "1.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lab": "5.7.x"
   },
   "dependencies": {
-    "hoek": "2.12.x"
+    "hoek": "2.12.x",
+    "insync": "^1.0.0"
   }
 }


### PR DESCRIPTION
Allow `generateKey` to return `undefined` to skip the cache.
Changed the schema of `response.plugins.tacky` to allow logic to be moved out of this plugin.

Per: https://github.com/caolan/async/pull/85#issuecomment-13072390, calling the "done" function out of order is the way to exit a waterfall early.
