### PR TITLE
Changed context to be global

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ These are the available options passed into Tack during plugin registration (`se
   - 'public' - mark the response as suitable for public caching.
   - 'private' - mark the response as suitable only for private caching.
 - `cache` - name of the cache provision to use if it has already been created by the hapi server. If specified, the cache must already exist before registration. Defaults to the default in-memory hapi cache.
+- `bind` - context object for `hydrate` and `generateKey`. Defaults to `undefined`.
 
 ### `cache` Route Handler Options
 
@@ -85,32 +86,3 @@ tacky provides two additional data points throughout the request lifecycle via `
     - `ttl` - number of milliseconds remaining for this cache record
     - `privacy` - privacy setting used for the cache header
   - `state` - object passed into the callback of the `hydrate` method. Will be `null` if not provided by the callback to the `hydrate` method.
-
-__context__
-The `this` pointer for `hydrate` and `generateKey` can be controlled via the `bind` option for the [route handler](https://github.com/hapijs/hapi/blob/master/API.md#route-options).
-
-Example:
-
-```js
-config: {
-  handler: {
-    cache: {
-      hydrate: function (request, callback) {
-
-        // this is {foo: 'bar', baz: true}
-        callback(null, this.baz);
-      },
-      generateKey: function (request) {
-
-        // this is {foo: 'bar', baz: true}
-        // don't do this because nothing will cache
-        return Date.now() + this.foo;
-      }
-    }
-  },
-  bind: {
-    foo: 'bar',
-    baz: true
-  }
-}
-```

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,14 @@ internals.extensionPoint = function (request, reply) {
 
     if (tacky.cache) {
         var cache = tacky.cache;
+        var ttl = internals.between(0, cache.ttl);
+
         response.header('cache-control', internals.getCacheString(cache.ttl, cache.privacy));
     }
     reply.continue();
+};
+
+internals.between = function (min, max) {
+
+    return Math.floor(Math.random() * (max - min + 1) + min);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,14 +11,13 @@ var internals = {};
 exports.register = function (server, options, next) {
 
     internals.settings = Hoek.applyToDefaults(defaults, options);
-
     internals.cache = server.cache({
         expiresIn: internals.settings.expiresIn,
         cache: internals.settings.cache
     });
 
     server.ext('onPreResponse', internals.extensionPoint);
-    server.handler('cache', internals.handler);
+    server.handler('cache', internals.handler.bind(options.bind));
     next();
 };
 
@@ -42,14 +41,14 @@ internals.handler = function (route, options) {
         }
     }, options);
 
+    var self = this;
     return function (request, reply) {
 
-        var context = request.route.settings.bind;
-        var cacheKey = settings.generateKey.call(context, request);
+        var cacheKey = settings.generateKey.call(self, request);
         var privacy = options.privacy || internals.settings.privacy;
 
         // Waterfall functions
-        var hydrate = settings.hydrate.bind(context, request);
+        var hydrate = settings.hydrate.bind(self, request);
         var done = function (err, data) {
 
             if (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -408,9 +408,13 @@ describe('tacky', function () {
         });
     });
 
-    it('will pass the handler bind context to the hydrate function', function (done) {
+    it('will pass the context option to the hydrate and generateKey function', function (done) {
 
         var server = new Hapi.Server({ debug: false });
+        var context = {
+            foo: 'bar',
+            baz: true
+        };
         server.connection();
 
         Insync.series([
@@ -418,7 +422,7 @@ describe('tacky', function () {
 
                 server.register({
                     register: Tacky,
-                    options: { expiresIn: 100000 }
+                    options: { expiresIn: 100000, bind: context }
                 }, next);
             }, function (next) {
 
@@ -430,18 +434,16 @@ describe('tacky', function () {
                             cache: {
                                 hydrate: function (request, callback) {
 
-                                    expect(this).to.deep.equal({
-                                        foo: 'bar',
-                                        baz: true
-                                    });
+                                    expect(this).to.deep.equal(context);
                                     callback(null, true);
+                                },
+                                generateKay: function (request) {
+
+                                    expect(this).to.deep.equal(context);
+                                    return request.raw.req.url;
                                 },
                                 privacy: 'private'
                             }
-                        },
-                        bind: {
-                            foo: 'bar',
-                            baz: true
                         }
                     }
                 });


### PR DESCRIPTION
Updated code to include global context options. This replaces the `bind` option in the route config.
