### PR TITLE
Store the state value in the cache as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ These are the available options passed into Tack during plugin registration (`se
   - `request` - the incoming hapi request
   - `callback(err, result[, state])` - function to execute when hydrate is finished.
     - `err` - any error during processing. If this value is truthy, the request will result in a 500 and the request will _not_ be cached.
-    - `result` - the value to save in the cache.
-    - `[state]` - this value will be attached to `request.response.plugins.tacky.state` so it will be available during the various request lifecycle methods. Defaults to `null`.
+    - `result` - the value to save in the cache and will be used in responses via `reply(response)`.
+    - `[state]` - this value will be attached to `request.response.plugins.tacky.state` so it will be available during the various request lifecycle methods. Defaults to `null`. `state` is also stored in the cache so it should only contain information truly necessary for generating a cached response and should *not* include any request specific information.
 - `[privacy]` - override the global `privacy` setting on a per route basis.
 - `[expiresIn]` - override the global `expiresIn` setting on a per route basis.
 - `[generateKey(request)]` - a function used to generate the cache key. The default value will return `request.raw.req.url`. If `undefined` is returned, cache lookup and storage will be completely skilled. All other results must be strings.

--- a/examples/state.js
+++ b/examples/state.js
@@ -1,0 +1,58 @@
+var Http = require('http');
+
+var Hapi = require('hapi');
+var Hoek = require('hoek');
+
+var Tacky = require('../lib');
+
+var server = new Hapi.Server();
+server.connection({ port: 9001 });
+
+server.register({
+  register: Tacky
+}, function (err) {
+
+  server.route({
+    method: 'get',
+    path: '/',
+    config: {
+      handler: {
+        cache: {
+            hydrate: function (request, callback) {
+              Http.get('http://www.google.com', function (res) {
+                var data = '';
+                res.on('data', function (chunk) {
+                  data += chunk;
+                });
+                res.on('end', function () {
+                  setTimeout(function () {
+                    callback(null, data, {
+                      statusCode: 202
+                    });
+                  }, 1000);
+                });
+              });
+            }
+        }
+      }
+    }
+  });
+  server.start(function () {
+    console.log('Server started at ' + server.info.uri)
+  });
+  server.ext('onPreResponse', function (request, reply) {
+
+    var response = request.response;
+
+    if (response.isBoom) {
+        return reply.continue();
+    }
+
+    var state = Hoek.reach(response, 'plugins.tacky.state');
+
+    if (state) {
+      response.statusCode = state.statusCode;
+    }
+    reply.continue();
+  });
+});

--- a/examples/state.js
+++ b/examples/state.js
@@ -1,8 +1,6 @@
 var Http = require('http');
-
 var Hapi = require('hapi');
 var Hoek = require('hoek');
-
 var Tacky = require('../lib');
 
 var server = new Hapi.Server();

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,13 +106,13 @@ internals.handler = function (route, options) {
                 // an async waterfall (https://github.com/caolan/async/pull/85#issuecomment-13072390).
                 if (cached) {
                     return done(null, {
-                        result: value,
+                        result: value.result,
                         cache: {
                             ttl: cached.ttl,
                             maxAge: cached.ttl,
                             privacy: privacy
                         },
-                        state: null
+                        state: value.state
                     });
                 }
                 next(null);
@@ -131,7 +131,11 @@ internals.handler = function (route, options) {
             tasks.push(function (arg, next) {
 
                 var tail = request.tail('cache tail');
-                internals.cache.set(cacheKey, arg.result, arg.cache.ttl, function (cacheErr) {
+                var value = {
+                    result: arg.result,
+                    state: arg.state
+                };
+                internals.cache.set(cacheKey, value, arg.cache.ttl, function (cacheErr) {
 
                     if (cacheErr) {
                         request.log(['cache', 'error'], {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "code": "1.4.x",
     "hapi": "8.4.x",
-    "insync": "1.0.x",
     "lab": "5.7.x"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #12 

`state` would only be available the first time `hydrate` is called which is the opposite of useful, so we are storing that as well in the cache.

Added example.
